### PR TITLE
add get_items_from_community_tab search loop

### DIFF
--- a/src/youtube_community_tab/community_tab.py
+++ b/src/youtube_community_tab/community_tab.py
@@ -134,8 +134,11 @@ class CommunityTab(object):
 
     @staticmethod
     def get_community_tab(tabs):
-        COMMUNITY_TAB_INDEX = 3
-
+        COMMUNITY_TAB_INDEX = 0
+        for tabs_community in tabs:
+            if tabs_community["tabRenderer"]["endpoint"]["commandMetadata"]["webCommandMetadata"]["url"].find('community') is not -1:
+                break
+            COMMUNITY_TAB_INDEX = COMMUNITY_TAB_INDEX+1
         if len(tabs) >= COMMUNITY_TAB_INDEX + 1:
             return tabs[COMMUNITY_TAB_INDEX]
         else:


### PR DESCRIPTION
If youtuber's channel have "live" tag, It will make tabs get the wrong tabRenderer.